### PR TITLE
Adding `@NoSpell` Syntax

### DIFF
--- a/templates/_help.colortemplate
+++ b/templates/_help.colortemplate
@@ -36,6 +36,12 @@ Set to 1 if you want to hide the vertical split bar.
 	let g:@optionprefix_hide_vert_split = 0
 <
 
+						*g:@optionprefix_enhance_spell_check*
+Disable spell check for certain syntax. Check issue #4.
+>
+	let g:@optionprefix_hide_vert_split = 0
+<
+
 		    *g:@optionprefix_enable_filetype_specific_highlighting_group*
 Set to 1 if you really want to enable filetype specific highlighting. This
 might cause issue in https://github.com/vim/vim/issues/4405, use at your own

--- a/templates/paper.colortemplate
+++ b/templates/paper.colortemplate
@@ -70,6 +70,10 @@ Include: _syntax
 Include: _language
 #endif
 
+#if get(g:, '@optionprefix_enhance_spell_check', 0)
+Include: _spell
+#endif
+
 Include: _plug
 # }}}
 
@@ -100,6 +104,10 @@ Include: _syntax
 
 #if get(g:, '@optionprefix_enable_filetype_specific_highlighting_group', 0)
 Include: _language
+#endif
+
+#if get(g:, '@optionprefix_enhance_spell_check', 0)
+Include: _spell
 #endif
 
 Include: _plug


### PR DESCRIPTION
Add special syntax to disable Vim spell checking certain words.

c.c. #4 